### PR TITLE
Support for clustered (multi-server) setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM debian:jessie
 MAINTAINER Justin Plock <justin@plock.net>
 
 RUN apt-get update && apt-get install -y openjdk-7-jre-headless wget
-RUN wget -q -O - http://apache.mirrors.pair.com/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz | tar -xzf - -C /opt \
-    && mv /opt/zookeeper-3.4.6 /opt/zookeeper \
+RUN wget -q -O - http://apache.mirrors.pair.com/zookeeper/zookeeper-3.4.14/zookeeper-3.4.14.tar.gz | tar -xzf - -C /opt \
+    && mv /opt/zookeeper-3.4.14 /opt/zookeeper \
     && cp /opt/zookeeper/conf/zoo_sample.cfg /opt/zookeeper/conf/zoo.cfg \
     && mkdir -p /tmp/zookeeper
 
@@ -25,5 +25,7 @@ WORKDIR /opt/zookeeper
 
 VOLUME ["/opt/zookeeper/conf", "/tmp/zookeeper"]
 
-ENTRYPOINT ["/opt/zookeeper/bin/zkServer.sh"]
+COPY docker-entrypoint.sh /opt/zookeeper/
+
+ENTRYPOINT ["/opt/zookeeper/docker-entrypoint.sh"]
 CMD ["start-foreground"]

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ docker-zookeeper
 
 Builds a docker image for Zookeeper.
 
-```docker build -t <user>/zookeeper:3.4.6 .```
+```docker build -t <user>/zookeeper:3.4.14 .```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,31 @@
+version: "3.7"
+services:
+  zoo1:
+    build: ./
+    environment:
+      SERVER_ID: "1"
+      SERVERS: "server.1=0.0.0.0:2888:3888,server.2=zoo2:2888:3888,server.3=zoo3:2888:3888"
+    hostname: zoo1
+    image: zookeeper
+    ports:
+      - "2181:2181"
+
+  zoo2:
+    build: ./
+    environment:
+      SERVER_ID: "2"
+      SERVERS: "server.1=zoo1:2888:3888,server.2=0.0.0.0:2888:3888,server.3=zoo3:2888:3888"
+    hostname: zoo2
+    image: zookeeper
+    ports:
+      - "2182:2181"
+
+  zoo3:
+    build: ./
+    environment:
+      SERVER_ID: "3"
+      SERVERS: "server.1=zoo1:2888:3888,server.2=zoo2:2888:3888,server.3=0.0.0.0:2888:3888"
+    hostname: zoo3
+    image: zookeeper
+    ports:
+      - "2183:2181"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Command to start zookeeper (start-foreground)
+CMD=$1
+
+# This ZooKeeper node ID, stored in 'myid' file
+if [ ! -z "$SERVER_ID" ]
+then
+  echo "$SERVER_ID" > /tmp/zookeeper/myid
+fi
+
+# Comma separated values with the form of 'server.X=host:port:port' 
+if [ ! -z "$SERVERS" ]
+then
+  for server in $(echo $SERVERS | sed "s/,/ /g")
+  do 
+    echo "$server" >> /opt/zookeeper/conf/zoo.cfg
+  done
+fi
+
+/opt/zookeeper/bin/zkServer.sh "$CMD"


### PR DESCRIPTION
## Description of the change

**Note**: upgrade ZooKeeper version to 3.4.14

This PR adds support for setting up a clustered ZooKeeper instance. In order to setup a ZooKeeper ensemble next env variables must be provided when running a container:

* SERVER_ID: the ID associated to the ZooKeeper server running in the container (`myid`'s file content).
* SERVERS: comma separated value with all the hosts that form the ensemble, for example:
   ```
   server.1=zoo1:2888:3888,server.2=zoo2:2888:3888,server.3=zoo3:2888:3888
   ```

Additionally, a sample `docker-compose.yaml` file is included to setup a ensemble with 3 nodes.